### PR TITLE
removed protect on processOrder

### DIFF
--- a/routes/checkout-route.js
+++ b/routes/checkout-route.js
@@ -11,6 +11,6 @@ const {
 const router = express.Router();
 
 router.post('/', protect,processCart);
-router.get("/:userId",protect,verifyPayment,getPaymentDetails,processOrder);
+router.get("/:userId",verifyPayment,getPaymentDetails,processOrder);
 
 module.exports = router;


### PR DESCRIPTION
Removed protect on process order because we don't want to append the token to the url